### PR TITLE
puppet.imagine not finishing FIX

### DIFF
--- a/src/interfaces/puppet.interface.ts
+++ b/src/interfaces/puppet.interface.ts
@@ -1,5 +1,6 @@
 import {ElementHandle} from "puppeteer"
 import Ids from "./ids.interface"
+import {ValidateFn} from "../types/callback";
 
 export default interface PuppetInterface {
     start(serverId?: string)
@@ -19,5 +20,5 @@ export default interface PuppetInterface {
     login(): Promise<boolean>
     isLoggedIn(): Promise<boolean>
     waitLogin(): Promise<boolean>
-    waitElement(requiredEval: string, validate?: (ElementHandle) => Promise<boolean>)
+    waitElement(requiredEval: string, validate?: ValidateFn)
 }

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -6,6 +6,7 @@ import * as console from "console"
 import {Message, Ids, Option} from "./interfaces"
 import clickByText from "./utils/click-by-text"
 import {Label} from "./utils/language-pack";
+import {ValidateFn} from "./types/callback";
 
 export default class Puppet {
     protected browser: Browser
@@ -234,7 +235,7 @@ export default class Puppet {
         return isLoggedIn
     }
 
-    async waitElement(requiredEval: string, validate?: (ElementHandle) => Promise<boolean>) {
+    async waitElement(requiredEval: string, validate?: ValidateFn) {
         let tryCount = 0
 
         while (tryCount < this.options.waitElement) {

--- a/src/types/callback.ts
+++ b/src/types/callback.ts
@@ -1,0 +1,4 @@
+import {ElementHandle} from "puppeteer";
+
+export type LoadingFn = (imageUrl: string) => void
+export type ValidateFn = (element: ElementHandle) => Promise<boolean>


### PR DESCRIPTION
fix: use url.includes() instead of url.endsWith() because midjourney urls now contains parameters at the end of the image

task: isolate validateImageTask logic
task: add typing for callbacks
